### PR TITLE
Add public snapshot read model for catalog pages and sitemap generation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,6 @@
 **/node_modules
 **/.next
+**/.public-data
 **/test-results
 **/playwright-report
 **/blob-report

--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ CONTACT_TO_EMAIL=kaymcline@gmail.com,sendtomakon@gmail.com
 
 # Optional config
 CONTACT_BCC_EMAIL=sendtomakon@gmail.com
+# Defaults to .public-data under the app working directory.
+PUBLIC_SNAPSHOT_DIR=
+# Optional token for GET /api/public-snapshot/refresh?token=...
+PUBLIC_SNAPSHOT_REFRESH_TOKEN=
 
 # Build-time-only variables
 # Optional. Defaults to images.daylilycatalog.com when unset.

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 
 # production
 /build
+.public-data
+packages/app/.public-data
 
 # misc
 .DS_Store

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -10,9 +10,9 @@ This app deploys as a Docker image on a single VPS. Public traffic reaches the c
 - Health endpoint: `GET /api/health`
 - Smoke-test path: `/api/health`
 - GHCR image: `ghcr.io/makoncline/rolling-oaks-daylilies`
-- Persistent volumes: none
+- Persistent volumes: optional public snapshot cache at `/app/.public-data`
 
-The container runs the Next.js standalone server from the image. The source repo is not required on the VPS at runtime.
+The container runs the Next.js standalone server from the image. The source repo is not required on the VPS at runtime. Public catalog pages render from a local public-data snapshot. If the snapshot is missing, the app rebuilds it from Turso on first use and writes it to `PUBLIC_SNAPSHOT_DIR` or `/app/.public-data`. If the snapshot is older than the app's freshness window, requests keep serving the stale snapshot and trigger one background refresh.
 
 ## External Services
 
@@ -20,7 +20,7 @@ The container runs the Next.js standalone server from the image. The source repo
 - Gmail SMTP for contact and cart emails
 - Resized image CDN at `images.daylilycatalog.com`
 
-`/api/health` performs a lightweight Turso database check with `SELECT 1`. SMTP is intentionally not checked because a probe would need to log in to Gmail on every request and can be slow or rate-limited; successful contact/cart form submissions exercise SMTP separately.
+`/api/health` reports public snapshot status and performs a lightweight Turso database check with `SELECT 1`. SMTP is intentionally not checked because a probe would need to log in to Gmail on every request and can be slow or rate-limited; successful contact/cart form submissions exercise SMTP separately.
 
 ## Environment
 
@@ -40,6 +40,8 @@ Required non-secret config:
 Optional config:
 
 - `CONTACT_BCC_EMAIL`: comma-separated BCC recipient list.
+- `PUBLIC_SNAPSHOT_DIR`: writable directory for the public read-model snapshot. Defaults to `.public-data` under the app working directory.
+- `PUBLIC_SNAPSHOT_REFRESH_TOKEN`: enables protected `GET /api/public-snapshot/refresh?token=...` for manual refreshes.
 
 Build-time-only variables:
 
@@ -87,15 +89,35 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    volumes:
+      - public-data:/app/.public-data
     networks:
       - edge
+
+volumes:
+  public-data:
 
 networks:
   edge:
     external: true
 ```
 
-The service does not publish host ports. Caddy reaches it over the external `edge` Docker network.
+The service does not publish host ports. Caddy reaches it over the external `edge` Docker network. The `public-data` volume preserves the generated public snapshot across container recreates; it is safe to delete because the app can rebuild it from Turso.
+
+## Public Snapshot Refresh
+
+Public catalog, listing, and sitemap routes read from a local snapshot instead of querying Turso on request. The app builds the snapshot on first use if it is missing. To refresh it manually, set `PUBLIC_SNAPSHOT_REFRESH_TOKEN` and open the protected endpoint:
+
+```sh
+curl --fail-with-body \
+  "http://app:3000/api/public-snapshot/refresh?token=${PUBLIC_SNAPSHOT_REFRESH_TOKEN}"
+```
+
+The app also self-refreshes: snapshots are fresh for 1 hour, and stale snapshots are served while a background refresh runs. Use this endpoint for an explicit refresh after admin data changes or when you want to refresh immediately. If a refresh fails, the app keeps serving the previous snapshot from the `public-data` volume and `/api/health` reports the snapshot age/status.
+
+Self-refresh is request-driven. If nobody visits the site and no one calls the refresh endpoint, the container does not rebuild snapshots unnecessarily.
+
+Snapshot refreshes emit structured JSON logs with `component: "public-snapshot"` and events such as `public_snapshot_build_started`, `public_snapshot_build_succeeded`, `public_snapshot_written`, `public_snapshot_build_failed`, and `public_snapshot_manual_refresh_requested`. These are intended for VPS log inspection.
 
 ## Caddy Route
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,9 +37,12 @@ ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
+ENV PUBLIC_SNAPSHOT_DIR=/app/.public-data
 
 RUN groupadd --system --gid 1001 nodejs \
-  && useradd --system --uid 1001 --gid nodejs nextjs
+  && useradd --system --uid 1001 --gid nodejs nextjs \
+  && mkdir -p /app/.public-data \
+  && chown nextjs:nodejs /app/.public-data
 
 COPY --from=builder --chown=nextjs:nodejs /app/packages/app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/packages/app/node_modules/@libsql ./packages/app/node_modules/@libsql

--- a/packages/app/.env.example
+++ b/packages/app/.env.example
@@ -9,6 +9,10 @@ CONTACT_TO_EMAIL=kaymcline@gmail.com,sendtomakon@gmail.com
 
 # Optional config
 CONTACT_BCC_EMAIL=sendtomakon@gmail.com
+# Defaults to .public-data under the app working directory.
+PUBLIC_SNAPSHOT_DIR=
+# Optional token for GET /api/public-snapshot/refresh?token=...
+PUBLIC_SNAPSHOT_REFRESH_TOKEN=
 
 # Build-time-only variables
 # Optional. Defaults to images.daylilycatalog.com when unset.

--- a/packages/app/lib/publicSnapshot.ts
+++ b/packages/app/lib/publicSnapshot.ts
@@ -1,0 +1,541 @@
+import { createHash } from "crypto";
+import { mkdir, readFile, rename, stat, writeFile } from "fs/promises";
+import path from "path";
+import { siteConfig } from "../siteConfig";
+import { prisma } from "../prisma/db";
+import {
+  AhsDisplay,
+  fullCultivarReferenceInclude,
+  mapListingCultivarDisplay,
+} from "./cultivarDisplay";
+
+const SNAPSHOT_SCHEMA_VERSION = 1;
+const HIDDEN_STATUS = "HIDDEN";
+export const PUBLIC_SNAPSHOT_FRESH_FOR_SECONDS = 60 * 60;
+export const PUBLIC_SNAPSHOT_MAX_STALE_SECONDS = 24 * 60 * 60;
+
+export type PublicImage = {
+  id: string;
+  url: string;
+  order: number;
+};
+
+export type PublicListRef = {
+  id: string;
+  slug: string;
+  title: string;
+  description: string | null;
+};
+
+export type PublicCatalogSummary = {
+  slug: string;
+  name: string;
+  intro: string | null;
+  image: string | null;
+  totalCount: number;
+  listingIds: string[];
+};
+
+export type PublicListingCard = {
+  id: string;
+  userId: string;
+  slug: string;
+  title: string;
+  price: number | null;
+  description: string | null;
+  status: string | null;
+  updatedAt: string;
+  images: PublicImage[];
+  lists: PublicListRef[];
+  ahsListing: AhsDisplay | null;
+};
+
+export type PublicSitemapEntry = {
+  path: string;
+  lastmod: string;
+};
+
+export type PublicSnapshot = {
+  schemaVersion: typeof SNAPSHOT_SCHEMA_VERSION;
+  version: string;
+  generatedAt: string;
+  userId: string;
+  catalogsBySlug: Record<string, PublicCatalogSummary>;
+  cardsById: Record<string, PublicListingCard>;
+  detailsBySlug: Record<string, PublicListingCard>;
+  sitemapEntries: PublicSitemapEntry[];
+  counts: {
+    visibleListings: number;
+    forSaleVisibleListings: number;
+    catalogs: number;
+    visibleListingImages: number;
+  };
+};
+
+type SnapshotManifest = {
+  schemaVersion: typeof SNAPSHOT_SCHEMA_VERSION;
+  version: string;
+  path: string;
+  generatedAt: string;
+  counts: PublicSnapshot["counts"];
+};
+
+const logPublicSnapshot = (
+  event: string,
+  payload: Record<string, unknown> = {}
+) => {
+  console.log(
+    JSON.stringify({
+      event,
+      service: "rolling-oaks-daylilies",
+      component: "public-snapshot",
+      timestamp: new Date().toISOString(),
+      ...payload,
+    })
+  );
+};
+
+let memo:
+  | {
+      manifestMtimeMs: number;
+      snapshot: PublicSnapshot;
+    }
+  | undefined;
+let refreshInFlight: Promise<PublicSnapshot> | undefined;
+
+export const getCatalogSlug = (title: string) =>
+  title.toLowerCase().replace(/\s+/g, "-");
+
+const getSnapshotDir = () =>
+  process.env.PUBLIC_SNAPSHOT_DIR || path.join(process.cwd(), ".public-data");
+
+const getManifestPath = () => path.join(getSnapshotDir(), "manifest.json");
+
+const isMissingFileError = (error: unknown) =>
+  error instanceof Error && "code" in error && error.code === "ENOENT";
+
+const visibleListingWhere = {
+  userId: siteConfig.userId,
+  OR: [{ status: null }, { NOT: { status: HIDDEN_STATUS } }],
+};
+
+const toPublicImage = (image: { id: string; url: string; order: number }) => ({
+  id: image.id,
+  url: image.url,
+  order: image.order,
+});
+
+const toSitemapDate = (value: string | Date) =>
+  new Date(value).toISOString().split("T")[0];
+
+const hashStringToNumber = (value: string) => {
+  let hash = 0;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash = (hash * 31 + value.charCodeAt(index)) >>> 0;
+  }
+
+  return hash;
+};
+
+const pickCatalogImage = (
+  seed: string,
+  slug: string,
+  listingIds: string[],
+  cardsById: Record<string, PublicListingCard>
+) => {
+  const imageUrls = listingIds
+    .map((listingId) => cardsById[listingId]?.images[0]?.url)
+    .filter(Boolean) as string[];
+
+  if (imageUrls.length === 0) {
+    return null;
+  }
+
+  const imageIndex =
+    hashStringToNumber(`${seed}:${slug}:${imageUrls.length}`) %
+    imageUrls.length;
+  return imageUrls[imageIndex];
+};
+
+const assertPublicSnapshot = (snapshot: PublicSnapshot) => {
+  const listings = Object.values(snapshot.detailsBySlug);
+
+  if (listings.some((listing) => listing.userId !== siteConfig.userId)) {
+    throw new Error("Public snapshot includes a listing for another user.");
+  }
+
+  if (listings.some((listing) => listing.status === HIDDEN_STATUS)) {
+    throw new Error("Public snapshot includes a hidden listing.");
+  }
+
+  if (JSON.stringify(snapshot).includes("privateNote")) {
+    throw new Error("Public snapshot includes privateNote.");
+  }
+
+  if (listings.length !== snapshot.counts.visibleListings) {
+    throw new Error("Public snapshot visible listing count is inconsistent.");
+  }
+};
+
+export async function buildPublicSnapshot(): Promise<PublicSnapshot> {
+  const startedAt = Date.now();
+  const generatedAt = new Date().toISOString();
+  logPublicSnapshot("public_snapshot_build_started", {
+    userId: siteConfig.userId,
+  });
+
+  const [lists, rawListings] = await Promise.all([
+    prisma.list.findMany({
+      where: { userId: siteConfig.userId },
+      orderBy: { title: "asc" },
+    }),
+    prisma.listing.findMany({
+      where: visibleListingWhere,
+      include: {
+        cultivarReference: {
+          include: fullCultivarReferenceInclude,
+        },
+        images: {
+          orderBy: { order: "asc" },
+        },
+        lists: true,
+      },
+    }),
+  ]);
+
+  const listRefsById = Object.fromEntries(
+    lists.map((list) => [
+      list.id,
+      {
+        id: list.id,
+        slug: getCatalogSlug(list.title),
+        title: list.title,
+        description: list.description,
+      },
+    ])
+  );
+
+  const mappedListings = rawListings.map(mapListingCultivarDisplay);
+  const cardsById: Record<string, PublicListingCard> = {};
+  const detailsBySlug: Record<string, PublicListingCard> = {};
+
+  for (const listing of mappedListings) {
+    const listsForListing = listing.lists
+      .map((list) => listRefsById[list.id])
+      .filter(Boolean);
+    const images = listing.images.map(toPublicImage);
+    const base = {
+      id: listing.id,
+      userId: listing.userId,
+      slug: listing.slug,
+      title: listing.title,
+      price: listing.price,
+      description: listing.description,
+      status: listing.status,
+      updatedAt: listing.updatedAt.toISOString(),
+      lists: listsForListing,
+      ahsListing: listing.ahsListing,
+    };
+
+    cardsById[listing.id] = {
+      ...base,
+      images: images.slice(0, 1),
+    };
+    detailsBySlug[listing.slug] = {
+      ...base,
+      images,
+    };
+  }
+
+  const allListingIds = mappedListings.map((listing) => listing.id);
+  const forSaleListingIds = mappedListings
+    .filter((listing) => listing.price && listing.price > 0)
+    .map((listing) => listing.id);
+  const listingIdsByCatalogSlug: Record<string, string[]> = {};
+
+  for (const list of lists) {
+    const slug = getCatalogSlug(list.title);
+    listingIdsByCatalogSlug[slug] = mappedListings
+      .filter((listing) => listing.lists.some((item) => item.id === list.id))
+      .map((listing) => listing.id);
+  }
+
+  const catalogsBySlug: Record<string, PublicCatalogSummary> = {
+    "for-sale": {
+      slug: "for-sale",
+      name: "For Sale",
+      intro:
+        "Daylilies available for purchase. Send me a message to check availability",
+      image: pickCatalogImage(
+        generatedAt,
+        "for-sale",
+        forSaleListingIds,
+        cardsById
+      ),
+      totalCount: forSaleListingIds.length,
+      listingIds: forSaleListingIds,
+    },
+    all: {
+      slug: "all",
+      name: "All Rolling Oaks Daylilies",
+      intro:
+        "View all of my daylilies in a single list. This is a great place to start if you're searching for something specific.",
+      image: pickCatalogImage(generatedAt, "all", allListingIds, cardsById),
+      totalCount: allListingIds.length,
+      listingIds: allListingIds,
+    },
+    search: {
+      slug: "search",
+      name: "Search",
+      intro: "",
+      image: pickCatalogImage(generatedAt, "search", allListingIds, cardsById),
+      totalCount: allListingIds.length,
+      listingIds: allListingIds,
+    },
+  };
+
+  for (const list of lists) {
+    const slug = getCatalogSlug(list.title);
+    const listingIds = listingIdsByCatalogSlug[slug] || [];
+    catalogsBySlug[slug] = {
+      slug,
+      name: list.title,
+      intro: list.description,
+      image: pickCatalogImage(generatedAt, slug, listingIds, cardsById),
+      totalCount: listingIds.length,
+      listingIds,
+    };
+  }
+
+  const staticSitemapEntries: PublicSitemapEntry[] = [
+    "",
+    "/",
+    "/catalogs",
+    "/catalog/all",
+    "/catalog/search",
+    "/catalog/for-sale",
+    "/cart",
+    "/thanks",
+    "/blog",
+    "/blog/dorothy-and-toto",
+  ].map((entryPath) => ({
+    path: entryPath,
+    lastmod: toSitemapDate(generatedAt),
+  }));
+
+  const catalogSitemapEntries = lists
+    .map((list) => {
+      const slug = getCatalogSlug(list.title);
+      const listingIds = listingIdsByCatalogSlug[slug] || [];
+      const latestListing = listingIds
+        .map((id) => cardsById[id])
+        .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt))
+        .at(-1);
+
+      if (!latestListing) return null;
+
+      return {
+        path: `/catalog/${slug}`,
+        lastmod: toSitemapDate(latestListing.updatedAt),
+      };
+    })
+    .filter(Boolean) as PublicSitemapEntry[];
+
+  const listingSitemapEntries = Object.values(detailsBySlug).map((listing) => ({
+    path: `/${listing.slug}`,
+    lastmod: toSitemapDate(listing.updatedAt),
+  }));
+
+  const visibleListingImages = Object.values(detailsBySlug).reduce(
+    (total, listing) => total + listing.images.length,
+    0
+  );
+
+  const snapshotWithoutVersion: Omit<PublicSnapshot, "version"> = {
+    schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+    generatedAt,
+    userId: siteConfig.userId,
+    catalogsBySlug,
+    cardsById,
+    detailsBySlug,
+    sitemapEntries: [
+      ...staticSitemapEntries,
+      ...catalogSitemapEntries,
+      ...listingSitemapEntries,
+    ],
+    counts: {
+      visibleListings: allListingIds.length,
+      forSaleVisibleListings: forSaleListingIds.length,
+      catalogs: lists.length,
+      visibleListingImages,
+    },
+  };
+
+  const hash = createHash("sha256")
+    .update(JSON.stringify(snapshotWithoutVersion))
+    .digest("hex")
+    .slice(0, 16);
+
+  const snapshot = {
+    ...snapshotWithoutVersion,
+    version: hash,
+  };
+
+  assertPublicSnapshot(snapshot);
+
+  logPublicSnapshot("public_snapshot_build_succeeded", {
+    version: snapshot.version,
+    durationMs: Date.now() - startedAt,
+    counts: snapshot.counts,
+  });
+
+  return snapshot;
+}
+
+export async function writePublicSnapshot(snapshot: PublicSnapshot) {
+  const snapshotDir = getSnapshotDir();
+  await mkdir(snapshotDir, { recursive: true });
+
+  const finalPath = path.join(
+    snapshotDir,
+    `public-snapshot.${snapshot.version}.json`
+  );
+  const tmpPath = `${finalPath}.tmp`;
+  const manifestPath = getManifestPath();
+  const manifestTmpPath = `${manifestPath}.tmp`;
+
+  await writeFile(tmpPath, JSON.stringify(snapshot), "utf8");
+  await rename(tmpPath, finalPath);
+
+  const manifest: SnapshotManifest = {
+    schemaVersion: SNAPSHOT_SCHEMA_VERSION,
+    version: snapshot.version,
+    path: finalPath,
+    generatedAt: snapshot.generatedAt,
+    counts: snapshot.counts,
+  };
+
+  await writeFile(manifestTmpPath, JSON.stringify(manifest), "utf8");
+  await rename(manifestTmpPath, manifestPath);
+
+  logPublicSnapshot("public_snapshot_written", {
+    version: snapshot.version,
+    path: finalPath,
+    manifestPath,
+  });
+
+  memo = undefined;
+}
+
+export async function refreshPublicSnapshot() {
+  try {
+    const snapshot = await buildPublicSnapshot();
+    await writePublicSnapshot(snapshot);
+    return snapshot;
+  } catch (error) {
+    logPublicSnapshot("public_snapshot_build_failed", {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}
+
+function refreshPublicSnapshotInBackground() {
+  if (!refreshInFlight) {
+    logPublicSnapshot("public_snapshot_background_refresh_started");
+    refreshInFlight = refreshPublicSnapshot().finally(() => {
+      refreshInFlight = undefined;
+    });
+  }
+
+  return refreshInFlight;
+}
+
+async function readPublicSnapshot() {
+  const manifestPath = getManifestPath();
+  const manifestStat = await stat(manifestPath);
+  if (memo && memo.manifestMtimeMs === manifestStat.mtimeMs) {
+    return memo.snapshot;
+  }
+
+  const manifest = JSON.parse(
+    await readFile(manifestPath, "utf8")
+  ) as SnapshotManifest;
+  const snapshot = JSON.parse(
+    await readFile(manifest.path, "utf8")
+  ) as PublicSnapshot;
+
+  memo = {
+    manifestMtimeMs: manifestStat.mtimeMs,
+    snapshot,
+  };
+
+  return snapshot;
+}
+
+export async function getExistingPublicSnapshot() {
+  try {
+    return await readPublicSnapshot();
+  } catch (error) {
+    if (isMissingFileError(error)) {
+      return null;
+    }
+
+    throw error;
+  }
+}
+
+export async function getPublicSnapshot(): Promise<PublicSnapshot> {
+  try {
+    const snapshot = await readPublicSnapshot();
+
+    if (
+      getPublicSnapshotAgeSeconds(snapshot) >=
+      PUBLIC_SNAPSHOT_FRESH_FOR_SECONDS
+    ) {
+      refreshPublicSnapshotInBackground().catch(() => undefined);
+    }
+
+    return snapshot;
+  } catch (error) {
+    if (!isMissingFileError(error)) {
+      throw error;
+    }
+
+    return refreshPublicSnapshot();
+  }
+}
+
+export function getPublicSnapshotAgeSeconds(snapshot: PublicSnapshot) {
+  return Math.max(
+    0,
+    Math.floor((Date.now() - new Date(snapshot.generatedAt).getTime()) / 1000)
+  );
+}
+
+export function isPublicSnapshotRefreshing() {
+  return Boolean(refreshInFlight);
+}
+
+export function getPublicSnapshotStatus(snapshot: PublicSnapshot) {
+  const ageSeconds = getPublicSnapshotAgeSeconds(snapshot);
+
+  if (ageSeconds < PUBLIC_SNAPSHOT_FRESH_FOR_SECONDS) {
+    return "fresh";
+  }
+
+  if (ageSeconds < PUBLIC_SNAPSHOT_MAX_STALE_SECONDS) {
+    return "stale";
+  }
+
+  return "expired";
+}
+
+export function getCatalogListings(
+  snapshot: PublicSnapshot,
+  catalogSlug: string
+) {
+  const listingIds = snapshot.catalogsBySlug[catalogSlug]?.listingIds || [];
+  return listingIds.map((id) => snapshot.cardsById[id]).filter(Boolean);
+}

--- a/packages/app/lib/publicSnapshot.ts
+++ b/packages/app/lib/publicSnapshot.ts
@@ -429,27 +429,29 @@ export async function writePublicSnapshot(snapshot: PublicSnapshot) {
 }
 
 export async function refreshPublicSnapshot() {
-  try {
-    const snapshot = await buildPublicSnapshot();
-    await writePublicSnapshot(snapshot);
-    return snapshot;
-  } catch (error) {
-    logPublicSnapshot("public_snapshot_build_failed", {
-      error: error instanceof Error ? error.message : String(error),
-    });
-    throw error;
-  }
-}
-
-function refreshPublicSnapshotInBackground() {
   if (!refreshInFlight) {
-    logPublicSnapshot("public_snapshot_background_refresh_started");
-    refreshInFlight = refreshPublicSnapshot().finally(() => {
+    refreshInFlight = (async () => {
+      try {
+        const snapshot = await buildPublicSnapshot();
+        await writePublicSnapshot(snapshot);
+        return snapshot;
+      } catch (error) {
+        logPublicSnapshot("public_snapshot_build_failed", {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    })().finally(() => {
       refreshInFlight = undefined;
     });
   }
 
   return refreshInFlight;
+}
+
+function refreshPublicSnapshotInBackground() {
+  logPublicSnapshot("public_snapshot_background_refresh_started");
+  return refreshPublicSnapshot();
 }
 
 async function readPublicSnapshot() {

--- a/packages/app/lib/sitemap.ts
+++ b/packages/app/lib/sitemap.ts
@@ -1,5 +1,5 @@
 import { siteConfig } from "siteConfig";
-import { prisma } from "../prisma/db";
+import { getPublicSnapshot } from "./publicSnapshot";
 
 export const getSitemapEntry = (path: string, lastmod: Date) => {
   return `
@@ -11,64 +11,9 @@ export const getSitemapEntry = (path: string, lastmod: Date) => {
 };
 
 export const getSitemapUrls = async () => {
-  const staticUrls = [
-    getSitemapEntry("", new Date()),
-    getSitemapEntry("/", new Date()),
-    getSitemapEntry("/catalogs", new Date()),
-    getSitemapEntry("/catalog/all", new Date()),
-    getSitemapEntry("/catalog/search", new Date()),
-    getSitemapEntry("/catalog/for-sale", new Date()),
-    getSitemapEntry("/cart", new Date()),
-    getSitemapEntry("/thanks", new Date()),
-    getSitemapEntry("/blog", new Date()),
-    getSitemapEntry("/blog/dorothy-and-toto", new Date()),
-  ];
+  const snapshot = await getPublicSnapshot();
 
-  const catalogs = await prisma.list.findMany({
-    select: {
-      title: true,
-      updatedAt: true,
-      listings: {
-        select: {
-          updatedAt: true,
-        },
-        where: {
-          OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-        },
-        orderBy: {
-          updatedAt: "asc",
-        },
-        take: 1,
-      },
-    },
-    where: { userId: siteConfig.userId },
-  });
-
-  const filteredCatalogs = catalogs.filter(
-    (catalog) => catalog.listings.length > 0
+  return snapshot.sitemapEntries.map((entry) =>
+    getSitemapEntry(entry.path, new Date(entry.lastmod))
   );
-
-  const catalogUrls = filteredCatalogs.map((catalog) => {
-    return getSitemapEntry(
-      `/catalog/${catalog.title.toLowerCase().replace(/\s+/g, "-")}`,
-      catalog.listings[0].updatedAt
-    );
-  });
-
-  const listings = await prisma.listing.findMany({
-    select: {
-      slug: true,
-      updatedAt: true,
-    },
-    where: {
-      userId: siteConfig.userId,
-      OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-    },
-  });
-
-  const listingUrls = listings.map((listing) =>
-    getSitemapEntry(`/${listing.slug}`, listing.updatedAt)
-  );
-
-  return [...staticUrls, ...catalogUrls, ...listingUrls];
 };

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -7,6 +7,7 @@
     "build": "node scripts/validate-env.cjs && npx prisma generate --schema=prisma/schema.sqlite.prisma && next build",
     "start": "next start",
     "lint": "next lint",
+    "snapshot:build": "jiti scripts/build-public-snapshot.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui"
   },

--- a/packages/app/pages/[listing].tsx
+++ b/packages/app/pages/[listing].tsx
@@ -6,10 +6,7 @@ import cart from "@iconify/icons-ic/round-shopping-cart";
 import Layout from "../components/layout";
 import { DaylilyCatalogAd } from "../components/DaylilyCatAd";
 import { useSnackBar } from "components/snackBarProvider";
-import { Listing, Image } from "../prisma/generated/sqlite-client";
 import { useCart } from "components/cart";
-import { siteConfig } from "siteConfig";
-import { prisma } from "../prisma/db";
 import { ImageDisplay } from "components/ImageDisplay";
 import {
   Badge,
@@ -23,9 +20,8 @@ import {
 } from "@packages/design-system";
 import {
   AhsDisplay,
-  fullCultivarReferenceInclude,
-  mapListingCultivarDisplay,
 } from "../lib/cultivarDisplay";
+import { getPublicSnapshot, PublicListingCard } from "../lib/publicSnapshot";
 
 const traitLabels: Partial<Record<keyof AhsDisplay, string>> = {
   hybridizer: "Hybridizer",
@@ -54,13 +50,7 @@ function objectKeys<T extends {}>(obj: T): Array<keyof T> {
   return Object.keys(obj) as Array<keyof T>;
 }
 
-type DisplayListing = Listing & {
-  ahsListing: AhsDisplay | null;
-  images: Image[];
-  lists?: {
-    title: string;
-  } | null;
-};
+type DisplayListing = PublicListingCard;
 
 const LilyTemplate = ({ listing }: { listing: DisplayListing }) => {
   const description = `${
@@ -91,7 +81,7 @@ const LilyTemplate = ({ listing }: { listing: DisplayListing }) => {
     images,
     lists,
   } = listing;
-  const listName = lists?.title;
+  const listName = lists[0]?.title;
   const cartItem = listing.price && {
     id: listing.id,
     name: listing.title,
@@ -228,25 +218,8 @@ export async function getStaticPaths() {
 
 export async function getStaticProps(context: any) {
   const slug = context.params.listing;
-
-  const listing = await prisma.listing.findFirst({
-    where: {
-      userId: siteConfig.userId,
-      slug,
-      OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-    },
-    include: {
-      cultivarReference: {
-        include: fullCultivarReferenceInclude,
-      },
-      images: {
-        orderBy: { order: "asc" },
-      },
-      lists: {
-        select: { title: true },
-      },
-    },
-  });
+  const snapshot = await getPublicSnapshot();
+  const listing = snapshot.detailsBySlug[slug];
 
   if (!listing) {
     return {
@@ -256,10 +229,8 @@ export async function getStaticProps(context: any) {
 
   return {
     props: {
-      listing: JSON.parse(
-        JSON.stringify(mapListingCultivarDisplay(listing))
-      ),
+      listing,
     },
-    revalidate: 60,
+    revalidate: 900,
   };
 }

--- a/packages/app/pages/api/health.ts
+++ b/packages/app/pages/api/health.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "../../prisma/db";
 import {
-  getExistingPublicSnapshot,
+  getPublicSnapshot,
   getPublicSnapshotAgeSeconds,
   getPublicSnapshotStatus,
   isPublicSnapshotRefreshing,
@@ -19,21 +19,22 @@ export default async function handler(
     return;
   }
 
-  const snapshot = await getExistingPublicSnapshot().catch((error) => {
+  const snapshot = await getPublicSnapshot().catch((error) => {
     console.error(error);
     return null;
   });
 
-  const database = await prisma.$queryRaw`SELECT 1`
-    .then(() => true)
-    .catch((error) => {
-      console.error(error);
-      return false;
-    });
-  const canServePublicData = Boolean(snapshot) || database;
+  let database = false;
+  try {
+    await prisma.$queryRaw`SELECT 1`;
+    database = true;
+  } catch (error) {
+    console.error(error);
+  }
+  const ok = Boolean(snapshot);
 
-  res.status(canServePublicData ? 200 : 503).json({
-    ok: canServePublicData,
+  res.status(ok ? 200 : 503).json({
+    ok,
     service: "rolling-oaks-daylilies",
     publicSnapshot: snapshot
       ? {
@@ -48,7 +49,6 @@ export default async function handler(
         }
       : null,
     checks: {
-      canServePublicData,
       database,
       publicSnapshot: Boolean(snapshot),
     },

--- a/packages/app/pages/api/health.ts
+++ b/packages/app/pages/api/health.ts
@@ -1,5 +1,13 @@
 import type { NextApiRequest, NextApiResponse } from "next";
 import { prisma } from "../../prisma/db";
+import {
+  getExistingPublicSnapshot,
+  getPublicSnapshotAgeSeconds,
+  getPublicSnapshotStatus,
+  isPublicSnapshotRefreshing,
+  PUBLIC_SNAPSHOT_FRESH_FOR_SECONDS,
+  PUBLIC_SNAPSHOT_MAX_STALE_SECONDS,
+} from "../../lib/publicSnapshot";
 
 export default async function handler(
   req: NextApiRequest,
@@ -11,24 +19,38 @@ export default async function handler(
     return;
   }
 
-  try {
-    await prisma.$queryRaw`SELECT 1`;
-
-    res.status(200).json({
-      ok: true,
-      service: "rolling-oaks-daylilies",
-      checks: {
-        database: true,
-      },
-    });
-  } catch (error) {
+  const snapshot = await getExistingPublicSnapshot().catch((error) => {
     console.error(error);
-    res.status(503).json({
-      ok: false,
-      service: "rolling-oaks-daylilies",
-      checks: {
-        database: false,
-      },
+    return null;
+  });
+
+  const database = await prisma.$queryRaw`SELECT 1`
+    .then(() => true)
+    .catch((error) => {
+      console.error(error);
+      return false;
     });
-  }
+  const canServePublicData = Boolean(snapshot) || database;
+
+  res.status(canServePublicData ? 200 : 503).json({
+    ok: canServePublicData,
+    service: "rolling-oaks-daylilies",
+    publicSnapshot: snapshot
+      ? {
+          status: getPublicSnapshotStatus(snapshot),
+          version: snapshot.version,
+          generatedAt: snapshot.generatedAt,
+          ageSeconds: getPublicSnapshotAgeSeconds(snapshot),
+          freshForSeconds: PUBLIC_SNAPSHOT_FRESH_FOR_SECONDS,
+          maxStaleSeconds: PUBLIC_SNAPSHOT_MAX_STALE_SECONDS,
+          refreshing: isPublicSnapshotRefreshing(),
+          visibleListings: snapshot.counts.visibleListings,
+        }
+      : null,
+    checks: {
+      canServePublicData,
+      database,
+      publicSnapshot: Boolean(snapshot),
+    },
+  });
 }

--- a/packages/app/pages/api/public-snapshot/refresh.ts
+++ b/packages/app/pages/api/public-snapshot/refresh.ts
@@ -1,0 +1,48 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { refreshPublicSnapshot } from "../../../lib/publicSnapshot";
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  res.setHeader("Cache-Control", "no-store");
+  res.setHeader("Referrer-Policy", "no-referrer");
+
+  if (req.method !== "GET") {
+    res.setHeader("Allow", "GET");
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  const refreshToken = process.env.PUBLIC_SNAPSHOT_REFRESH_TOKEN;
+  if (!refreshToken) {
+    res.status(404).json({ error: "Snapshot refresh is not enabled" });
+    return;
+  }
+
+  const token = Array.isArray(req.query.token)
+    ? req.query.token[0]
+    : req.query.token;
+
+  if (token !== refreshToken) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  console.log(
+    JSON.stringify({
+      event: "public_snapshot_manual_refresh_requested",
+      service: "rolling-oaks-daylilies",
+      component: "public-snapshot",
+      timestamp: new Date().toISOString(),
+    })
+  );
+
+  const snapshot = await refreshPublicSnapshot();
+  res.status(200).json({
+    ok: true,
+    version: snapshot.version,
+    generatedAt: snapshot.generatedAt,
+    counts: snapshot.counts,
+  });
+}

--- a/packages/app/pages/catalog/[catalog].tsx
+++ b/packages/app/pages/catalog/[catalog].tsx
@@ -7,10 +7,8 @@ import download from "../../lib/download";
 import Paginate from "../../components/paginate";
 import LilyCard from "../../components/lilyCard";
 import { GetStaticProps, NextPage } from "next";
-import { Listing, List, Image } from "../../prisma/generated/sqlite-client";
 import { useSnackBar } from "../../components/snackBarProvider";
 import { siteConfig } from "../../siteConfig";
-import { prisma } from "../../prisma/db";
 import { sortTitlesLettersBeforeNumbers } from "../../lib/sort";
 import {
   Button,
@@ -21,20 +19,19 @@ import {
 } from "@packages/design-system";
 import { InferGetStaticPropsType } from "next";
 import { useRouter } from "next/router";
+import { parseLeadingNumber } from "../../lib/cultivarDisplay";
 import {
-  AhsDisplay,
-  fullCultivarReferenceInclude,
-  mapListingCultivarDisplay,
-  parseLeadingNumber,
-} from "../../lib/cultivarDisplay";
+  getCatalogListings,
+  getPublicSnapshot,
+  PublicListRef,
+  PublicListingCard,
+} from "../../lib/publicSnapshot";
 
 type Props = {
   title: string;
-  description: string;
+  description: string | null;
   listings: DisplayListing[];
 };
-
-const getListSlug = (title: string) => title.toLowerCase().replace(/\s+/g, "-");
 
 const SearchPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
   title,
@@ -140,7 +137,7 @@ const SearchPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
     return lilyArr.filter((node: DisplayListing) => {
       return (
         node.lists &&
-        node.lists.some((list: List) =>
+        node.lists.some((list: PublicListRef) =>
           list.title.toLowerCase().includes(filters.list.toLowerCase())
         )
       );
@@ -531,7 +528,9 @@ const SearchPage: NextPage<InferGetStaticPropsType<typeof getStaticProps>> = ({
                           new Set(
                             listings.flatMap((listing: DisplayListing) =>
                               listing.lists && listing.lists.length > 0
-                                ? listing.lists.map((list: List) => list.title)
+                                ? listing.lists.map(
+                                    (list: PublicListRef) => list.title
+                                  )
                                 : ["No List"]
                             )
                           )
@@ -955,44 +954,14 @@ export async function getStaticPaths() {
   };
 }
 
-type DisplayListing = Listing & {
-  ahsListing: AhsDisplay | null;
-  lists: List[];
-  images: Image[];
-};
+type DisplayListing = PublicListingCard;
 
 export type ListingType = DisplayListing;
 
 export const getStaticProps: GetStaticProps<Props> = async (context: any) => {
   const catalog = context.params.catalog;
-  let listingsWhere: any = {
-    userId: siteConfig.userId,
-    OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-  };
-  let list: any = undefined;
-
-  const defaultList = { id: "", title: "", description: "" };
-
-  if (catalog === "for-sale") {
-    listingsWhere = { ...listingsWhere, price: { gt: 0 } };
-    list = { ...defaultList, title: "For Sale", description: "" };
-  } else if (catalog === "all") {
-    list = { ...defaultList, title: "All", description: "" };
-  } else if (catalog === "search") {
-    list = { ...defaultList, title: "Search", description: "" };
-  } else {
-    const lists = await prisma.list.findMany({
-      where: { userId: siteConfig.userId },
-    });
-    list = lists.find((candidate) => getListSlug(candidate.title) === catalog);
-
-    if (list) {
-      listingsWhere = {
-        ...listingsWhere,
-        lists: { some: { id: list.id } },
-      };
-    }
-  }
+  const snapshot = await getPublicSnapshot();
+  const list = snapshot.catalogsBySlug[catalog];
 
   if (!list) {
     return {
@@ -1000,32 +969,18 @@ export const getStaticProps: GetStaticProps<Props> = async (context: any) => {
     };
   }
 
-  const rawListings = await prisma.listing.findMany({
-    include: {
-      cultivarReference: {
-        include: fullCultivarReferenceInclude,
-      },
-      lists: true,
-      images: {
-        orderBy: { order: "asc" },
-      },
-    },
-    where: listingsWhere,
-  });
-  const listings = rawListings.map(mapListingCultivarDisplay);
+  const listings = getCatalogListings(snapshot, catalog);
 
-  const title = list.title;
-  const description = list.description;
+  const title = list.name;
+  const description = list.intro;
 
   return {
-    props: JSON.parse(
-      JSON.stringify({
-        title,
-        description,
-        listings: listings,
-      })
-    ),
-    revalidate: 60,
+    props: {
+      title,
+      description,
+      listings,
+    },
+    revalidate: 900,
   };
 };
 

--- a/packages/app/pages/catalogs.tsx
+++ b/packages/app/pages/catalogs.tsx
@@ -1,14 +1,14 @@
 import React from "react";
-import slugify from "slugify";
 import Layout from "../components/layout";
 import { CatalogCard } from "../components/catalogCard";
 import { NextPage } from "next";
-import { siteConfig } from "../siteConfig";
-import { prisma } from "../prisma/db";
 import { Heading } from "@packages/design-system";
 import { getPlaceholderImageUrl } from "lib/getPlaceholderImage";
+import { getPublicSnapshot, PublicCatalogSummary } from "../lib/publicSnapshot";
 
-const Catalogs: NextPage<{ catalogs: Catalog[] }> = ({ catalogs }) => {
+const Catalogs: NextPage<{ catalogs: PublicCatalogSummary[] }> = ({
+  catalogs,
+}) => {
   return (
     <Layout>
       <Heading level={1}>Catalogs</Heading>
@@ -28,136 +28,20 @@ const Catalogs: NextPage<{ catalogs: Catalog[] }> = ({ catalogs }) => {
 
 export default Catalogs;
 
-export type Catalog = {
-  slug: string;
-  name: string;
-  intro: string | null;
-  totalCount: number;
-  image: string | null;
-};
-
-type ImageRow = {
-  url: string;
-};
-
-const randomListImageUrl = async (listId: string) => {
-  const rows = await prisma.$queryRaw<ImageRow[]>`
-    SELECT Image.url
-    FROM Image
-    JOIN Listing ON Listing.id = Image.listingId
-    JOIN _ListToListing ON _ListToListing.B = Listing.id
-    WHERE _ListToListing.A = ${listId}
-      AND Listing.userId = ${siteConfig.userId}
-      AND (Listing.status IS NULL OR Listing.status != 'HIDDEN')
-    ORDER BY RANDOM()
-    LIMIT 1
-  `;
-
-  return rows[0]?.url ?? null;
-};
-
-const randomAllListingsImageUrl = async () => {
-  const rows = await prisma.$queryRaw<ImageRow[]>`
-    SELECT Image.url
-    FROM Image
-    JOIN Listing ON Listing.id = Image.listingId
-    WHERE Listing.userId = ${siteConfig.userId}
-      AND (Listing.status IS NULL OR Listing.status != 'HIDDEN')
-    ORDER BY RANDOM()
-    LIMIT 1
-  `;
-
-  return rows[0]?.url ?? null;
-};
-
-const randomForSaleImageUrl = async () => {
-  const rows = await prisma.$queryRaw<ImageRow[]>`
-    SELECT Image.url
-    FROM Image
-    JOIN Listing ON Listing.id = Image.listingId
-    WHERE Listing.userId = ${siteConfig.userId}
-      AND Listing.price > 0
-      AND (Listing.status IS NULL OR Listing.status != 'HIDDEN')
-    ORDER BY RANDOM()
-    LIMIT 1
-  `;
-
-  return rows[0]?.url ?? null;
-};
-
-export async function getServerSideProps() {
-  const lists = await prisma.list.findMany({
-    where: { userId: siteConfig.userId },
-  });
-
-  const catalogs = await Promise.all(
-    lists.map(async (list) => {
-      const [totalCount, image] = await Promise.all([
-        prisma.listing.count({
-          where: {
-            lists: { some: { id: list.id } },
-            OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-          },
-        }),
-        randomListImageUrl(list.id),
-      ]);
-
-      return {
-        slug: list.title.toLowerCase().replace(/\s+/g, "-"),
-        name: list.title,
-        intro: list.description,
-        totalCount,
-        image,
-      };
-    })
-  );
-
-  // All listings catalog
-  const [allListingCountQuery, allListingImage] = await Promise.all([
-    prisma.listing.count({
-      where: {
-        userId: siteConfig.userId,
-        OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-      },
-    }),
-    randomAllListingsImageUrl(),
-  ]);
-
-  const allCatalog = {
-    slug: "all",
-    name: "All Rolling Oaks Daylilies",
-    intro: `View all of my daylilies in a single list. This is a great place to start if you're searching for something specific.`,
-    totalCount: allListingCountQuery,
-    image: allListingImage,
-  };
-
-  // For sale catalog
-  const [forSaleListingCountQuery, forSaleImage] = await Promise.all([
-    prisma.listing.count({
-      where: {
-        price: { gt: 0 },
-        userId: siteConfig.userId,
-        OR: [{ status: null }, { NOT: { status: "HIDDEN" } }],
-      },
-    }),
-    randomForSaleImageUrl(),
-  ]);
-
-  const forSaleCatalog = {
-    slug: "for-sale",
-    name: "For Sale",
-    intro: `Daylilies available for purchase. Send me a message to check availability`,
-    totalCount: forSaleListingCountQuery,
-    image: forSaleImage,
-  };
+export async function getStaticProps() {
+  const snapshot = await getPublicSnapshot();
+  const realCatalogs = Object.values(snapshot.catalogsBySlug)
+    .filter((catalog) => !["all", "search", "for-sale"].includes(catalog.slug))
+    .sort((a, b) => b.totalCount - a.totalCount);
 
   return {
     props: {
       catalogs: [
-        forSaleCatalog,
-        ...catalogs.sort((a, b) => b.totalCount - a.totalCount),
-        allCatalog,
-      ],
+        snapshot.catalogsBySlug["for-sale"],
+        ...realCatalogs,
+        snapshot.catalogsBySlug.all,
+      ].filter(Boolean),
     },
+    revalidate: 900,
   };
 }

--- a/packages/app/pages/catalogs.tsx
+++ b/packages/app/pages/catalogs.tsx
@@ -28,7 +28,7 @@ const Catalogs: NextPage<{ catalogs: PublicCatalogSummary[] }> = ({
 
 export default Catalogs;
 
-export async function getStaticProps() {
+export async function getServerSideProps() {
   const snapshot = await getPublicSnapshot();
   const realCatalogs = Object.values(snapshot.catalogsBySlug)
     .filter((catalog) => !["all", "search", "for-sale"].includes(catalog.slug))
@@ -42,6 +42,5 @@ export async function getStaticProps() {
         snapshot.catalogsBySlug.all,
       ].filter(Boolean),
     },
-    revalidate: 900,
   };
 }

--- a/packages/app/pages/sitemap.tsx
+++ b/packages/app/pages/sitemap.tsx
@@ -2,7 +2,7 @@ const Sitemap = () => null;
 
 export const getServerSideProps = async () => ({
   redirect: {
-    destination: "/404",
+    destination: "/api/sitemap",
     permanent: false,
   },
 });

--- a/packages/app/scripts/build-public-snapshot.ts
+++ b/packages/app/scripts/build-public-snapshot.ts
@@ -1,0 +1,12 @@
+import { refreshPublicSnapshot } from "../lib/publicSnapshot";
+
+refreshPublicSnapshot()
+  .then((snapshot) => {
+    console.log(
+      `Built public snapshot ${snapshot.version} with ${snapshot.counts.visibleListings} visible listings.`
+    );
+  })
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- Add a generated public snapshot read model to serve catalog, listing, and sitemap data without live Turso reads at build time
- Add refresh and health endpoints plus a build script to regenerate the snapshot
- Update deployment, env, and Docker files to support the new runtime and build flow

## Testing
- Not run (not requested)